### PR TITLE
fix:nginx template update to enable cors for /icons/ path

### DIFF
--- a/infra/docker/web/nginx.template.conf
+++ b/infra/docker/web/nginx.template.conf
@@ -11,6 +11,18 @@ server {
     proxy_set_header X-Forwarded-Proto $scheme;
   }
 
+  location /icons/ {
+    proxy_pass http://127.0.0.1:PORT_PLACEHOLDER;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Add CORS headers
+    add_header 'Access-Control-Allow-Origin' '*';
+    add_header 'Access-Control-Allow-Methods' 'GET, OPTIONS';
+    add_header 'Access-Control-Allow-Headers' '*';
+  }
+
   listen 443 ssl; # managed by Certbot
   ssl_certificate /etc/letsencrypt/live/DOMAIN_PLACEHOLDER/fullchain.pem; # managed by Certbot
   ssl_certificate_key /etc/letsencrypt/live/DOMAIN_PLACEHOLDER/privkey.pem; # managed by Certbot


### PR DESCRIPTION
fix: updated nginx template to allow cors for static icons path