### PR TITLE
chore:omitting the platforms option from docker buildx action to prev…

### DIFF
--- a/.github/workflows/main-deploy.yml
+++ b/.github/workflows/main-deploy.yml
@@ -231,7 +231,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64
+          # platforms: linux/amd64
           push: true
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/${{ steps.key_values.outputs.REPO_NAME }}:${{ steps.hash.outputs.git_hash }}


### PR DESCRIPTION
preventing multiple image layer creation per platform as docker buildx will pick github runner env arch (amd64) as the default platform which is the same as arch of our vpn instances