### PR TITLE
fix : extra phone field and workflow Reminder

### DIFF
--- a/apps/web/components/booking/BookingListItem.tsx
+++ b/apps/web/components/booking/BookingListItem.tsx
@@ -12,11 +12,7 @@ import { getSuccessPageLocationMessage, guessEventLocationType } from "@calcom/a
 import dayjs from "@calcom/dayjs";
 // TODO: Use browser locale, implement Intl in Dayjs maybe?
 import "@calcom/dayjs/locales";
-import {
-  SMS_REMINDER_NUMBER_FIELD,
-  SystemField,
-  TITLE_FIELD,
-} from "@calcom/features/bookings/lib/SystemField";
+import { SystemField, TITLE_FIELD } from "@calcom/features/bookings/lib/SystemField";
 import ViewRecordingsDialog from "@calcom/features/ee/video/ViewRecordingsDialog";
 import classNames from "@calcom/lib/classNames";
 import { formatTime } from "@calcom/lib/date-fns";
@@ -940,12 +936,13 @@ function BookingListItem(booking: BookingItemProps) {
                   // TITLE is also an identifier for booking question "What is this meeting about?"
                   if (
                     isSystemField.success &&
-                    field.name !== SMS_REMINDER_NUMBER_FIELD &&
+                    // field.name !== SMS_REMINDER_NUMBER_FIELD &&
                     field.name !== TITLE_FIELD
                   )
                     return null;
 
                   const label = String(field.label) || t(String(field.defaultLabel) || "");
+                  // const label = t(String(field.defaultLabel) || "");
 
                   return (
                     <div className="flex items-center" key={label}>

--- a/apps/web/modules/bookings/views/bookings-single-view.tsx
+++ b/apps/web/modules/bookings/views/bookings-single-view.tsx
@@ -27,11 +27,7 @@ import {
   useIsEmbed,
 } from "@calcom/embed-core/embed-iframe";
 import { Price } from "@calcom/features/bookings/components/event-meta/Price";
-import {
-  SMS_REMINDER_NUMBER_FIELD,
-  SystemField,
-  TITLE_FIELD,
-} from "@calcom/features/bookings/lib/SystemField";
+import { SystemField, TITLE_FIELD } from "@calcom/features/bookings/lib/SystemField";
 import { getOrgFullOrigin } from "@calcom/features/oe/organizations/lib/orgDomains";
 import { APP_NAME, ONEHASH_CHAT_ORIGIN, WEBAPP_URL } from "@calcom/lib/constants";
 import {
@@ -725,12 +721,13 @@ export default function Success(props: PageProps) {
                             // We show notes in additional notes section
                             // We show rescheduleReason at the top
                             if (!field) return null;
+
                             const isSystemField = SystemField.safeParse(field.name);
                             // SMS_REMINDER_NUMBER_FIELD is a system field but doesn't have a dedicated place in the UI. So, it would be shown through the following responses list
                             // TITLE is also an identifier for booking question "What is this meeting about?"
                             if (
                               isSystemField.success &&
-                              field.name !== SMS_REMINDER_NUMBER_FIELD &&
+                              // field.name !== SMS_REMINDER_NUMBER_FIELD &&
                               field.name !== TITLE_FIELD
                             )
                               return null;
@@ -843,7 +840,7 @@ export default function Success(props: PageProps) {
                               allRemainingBookings={allRemainingBookings}
                               seatReferenceUid={seatReferenceUid}
                               bookingCancelledEventProps={bookingCancelledEventProps}
-                              isLoggedInUserHost={!!props.isLoggedInUserHost ?? false}
+                              isLoggedInUserHost={!!(props.isLoggedInUserHost ?? false)}
                               currentUserEmail={currentUserEmail}
                             />
                           </>

--- a/packages/features/bookings/Booker/components/BookEventForm/BookingFields.tsx
+++ b/packages/features/bookings/Booker/components/BookEventForm/BookingFields.tsx
@@ -64,11 +64,22 @@ export const BookingFields = ({
           readOnly = false;
         }
 
-        if (field.name === SystemField.Enum.smsReminderNumber) {
+        // if (field.name === SystemField.Enum.smsReminderNumber) {
+        //   // `smsReminderNumber` and location.optionValue when location.value===phone are the same data point. We should solve it in a better way in the Form Builder itself.
+        //   // I think we should have a way to connect 2 fields together and have them share the same value in Form Builder
+        //   if (locationResponse?.value === "phone") {
+        //     setValue(`responses.${SystemField.Enum.smsReminderNumber}`, locationResponse?.optionValue);
+        //     // Just don't render the field now, as the value is already connected to attendee phone location
+        //     return null;
+        //   }
+        //   // `smsReminderNumber` can be edited during reschedule even though it's a system field
+        //   readOnly = false;
+        // }
+        if (field.name === SystemField.Enum.phone) {
           // `smsReminderNumber` and location.optionValue when location.value===phone are the same data point. We should solve it in a better way in the Form Builder itself.
           // I think we should have a way to connect 2 fields together and have them share the same value in Form Builder
           if (locationResponse?.value === "phone") {
-            setValue(`responses.${SystemField.Enum.smsReminderNumber}`, locationResponse?.optionValue);
+            setValue(`responses.${SystemField.Enum.phone}`, locationResponse?.optionValue);
             // Just don't render the field now, as the value is already connected to attendee phone location
             return null;
           }

--- a/packages/features/bookings/lib/SystemField.ts
+++ b/packages/features/bookings/lib/SystemField.ts
@@ -8,10 +8,11 @@ export const SystemField = z.enum([
   "notes",
   "guests",
   "rescheduleReason",
-  "smsReminderNumber",
+  // "smsReminderNumber",
   "phone",
   "attendeePhoneNumber",
 ]);
 
-export const SMS_REMINDER_NUMBER_FIELD = "smsReminderNumber";
+export const SMS_REMINDER_NUMBER_FIELD = "phone";
+
 export const TITLE_FIELD = "title";

--- a/packages/features/bookings/lib/handleNewBooking.ts
+++ b/packages/features/bookings/lib/handleNewBooking.ts
@@ -1097,7 +1097,8 @@ async function handler(
       attendeeLanguage,
       paymentAppData,
       fullName,
-      smsReminderNumber,
+      smsReminderNumber: bookerPhoneNumber,
+      //smsReminderNumber,
       eventTypeInfo,
       uid,
       eventTypeId,
@@ -1187,7 +1188,7 @@ async function handler(
           bookerEmail,
           rescheduleReason,
           changedOrganizer,
-          smsReminderNumber,
+          smsReminderNumber: bookerPhoneNumber,
           responses,
         },
         evt,
@@ -1790,7 +1791,7 @@ async function handler(
     metadata: { ...metadata, ...reqBody.metadata },
     eventTypeId,
     status: "ACCEPTED",
-    smsReminderNumber: booking?.smsReminderNumber || undefined,
+    smsReminderNumber: bookerPhoneNumber || undefined,
     rescheduledBy: reqBody.rescheduledBy,
     cancellationReason: "N/A",
   };
@@ -1998,7 +1999,7 @@ async function handler(
   try {
     await scheduleWorkflowReminders({
       workflows,
-      smsReminderNumber: smsReminderNumber || null,
+      smsReminderNumber: bookerPhoneNumber || null,
       calendarEvent: {
         ...evtWithMetadata,
         eventType: {

--- a/packages/features/bookings/lib/handleNewBooking/test/workflow-notifications.test.ts
+++ b/packages/features/bookings/lib/handleNewBooking/test/workflow-notifications.test.ts
@@ -128,7 +128,7 @@ describe("handleNewBooking", () => {
               email: booker.email,
               name: booker.name,
               location: { optionValue: "", value: BookingLocations.CalVideo },
-              smsReminderNumber: "000",
+              phone: "+911234567890",
             },
           },
         });
@@ -142,7 +142,7 @@ describe("handleNewBooking", () => {
 
         expectSMSWorkflowToBeTriggered({
           sms,
-          toNumber: "000",
+          toNumber: "+911234567890",
         });
 
         expectWorkflowToBeTriggered({
@@ -227,7 +227,7 @@ describe("handleNewBooking", () => {
               email: booker.email,
               name: booker.name,
               location: { optionValue: "", value: BookingLocations.CalVideo },
-              smsReminderNumber: "000",
+              phone: "+911234567890",
             },
           },
         });
@@ -241,7 +241,7 @@ describe("handleNewBooking", () => {
 
         expectSMSWorkflowToBeNotTriggered({
           sms,
-          toNumber: "000",
+          toNumber: "+911234567890",
         });
       },
       timeout
@@ -374,7 +374,7 @@ describe("handleNewBooking", () => {
               email: booker.email,
               name: booker.name,
               location: { optionValue: "", value: BookingLocations.CalVideo },
-              smsReminderNumber: "000",
+              phone: "+911234567890",
             },
           },
         });
@@ -388,7 +388,7 @@ describe("handleNewBooking", () => {
 
         expectSMSWorkflowToBeTriggered({
           sms,
-          toNumber: "000",
+          toNumber: "+911234567890",
         });
 
         expectWorkflowToBeTriggered({
@@ -519,7 +519,7 @@ describe("handleNewBooking", () => {
               email: booker.email,
               name: booker.name,
               location: { optionValue: "", value: BookingLocations.CalVideo },
-              smsReminderNumber: "000",
+              phone: "+911234567890",
             },
           },
         });
@@ -533,7 +533,7 @@ describe("handleNewBooking", () => {
 
         expectSMSWorkflowToBeNotTriggered({
           sms,
-          toNumber: "000",
+          toNumber: "+911234567890",
         });
       },
       timeout
@@ -755,7 +755,7 @@ describe("handleNewBooking", () => {
             email: booker.email,
             name: booker.name,
             location: { optionValue: "", value: BookingLocations.CalVideo },
-            smsReminderNumber: "000",
+            phone: "+911234567890",
           },
         },
       });
@@ -769,7 +769,7 @@ describe("handleNewBooking", () => {
 
       expectSMSWorkflowToBeTriggered({
         sms,
-        toNumber: "000",
+        toNumber: "+911234567890",
       });
     });
   });

--- a/packages/features/eventtypes/lib/bookingFieldsManager.ts
+++ b/packages/features/eventtypes/lib/bookingFieldsManager.ts
@@ -52,7 +52,7 @@ async function getEventType(eventTypeId: EventType["id"]) {
  * @param eventTypeId
  */
 export async function upsertBookingField(
-  fieldToAdd: Omit<Field, "required">,
+  // fieldToAdd: Omit<Field, "required">,
   source: NonNullable<Field["sources"]>[number],
   eventTypeId: EventType["id"]
 ) {
@@ -60,7 +60,7 @@ export async function upsertBookingField(
   let fieldFound = false;
 
   const newFields = eventType.bookingFields.map((f) => {
-    if (f.name === fieldToAdd.name) {
+    if (f.name === "phone") {
       fieldFound = true;
 
       const currentSources = f.sources ? f.sources : ([] as NonNullable<typeof f.sources>[]);
@@ -86,18 +86,19 @@ export async function upsertBookingField(
         // If any source requires the field, mark the field required
         required: newSources.some((s) => s.fieldRequired),
         sources: newSources,
+        hidden: false,
       };
       return newField;
     }
     return f;
   });
-  if (!fieldFound) {
-    newFields.push({
-      ...fieldToAdd,
-      required: source.fieldRequired,
-      sources: [source],
-    });
-  }
+  // if (!fieldFound) {
+  //   newFields.push({
+  //     ...fieldToAdd,
+  //     required: source.fieldRequired,
+  //     sources: [source],
+  //   });
+  // }
   await prisma.eventType.update({
     where: {
       id: eventTypeId,

--- a/packages/features/form-builder/FormBuilder.tsx
+++ b/packages/features/form-builder/FormBuilder.tsx
@@ -68,7 +68,7 @@ export const FormBuilder = function FormBuilder({
   description: string;
   addFieldLabel: string;
   disabled: boolean;
-  LockedIcon: false | JSX.Element;
+  LockedIcon?: false | JSX.Element | null;
   /**
    * A readonly dataStore that is used to lookup the options for the fields. It works in conjunction with the field.getOptionAt property which acts as the key in options
    */
@@ -178,11 +178,14 @@ export const FormBuilder = function FormBuilder({
             }
             const groupedBySourceLabel = sources.reduce((groupBy, source) => {
               const item = groupBy[source.label] || [];
-              if (source.type === "user" || source.type === "default") {
+              if (source.type === "user" || (source.type === "default" && field.name !== "phone")) {
                 return groupBy;
               }
-              item.push(source);
-              groupBy[source.label] = item;
+              if (source.type !== "default") {
+                item.push(source);
+                groupBy[source.label] = item;
+                return groupBy;
+              }
               return groupBy;
             }, {} as Record<string, NonNullable<(typeof field)["sources"]>>);
 
@@ -243,7 +246,7 @@ export const FormBuilder = function FormBuilder({
                     {!isFieldEditableSystem && !isFieldEditableSystemButHidden && !disabled && (
                       <Switch
                         data-testid="toggle-field"
-                        disabled={isFieldEditableSystem}
+                        disabled={field.sources?.some((s) => s.label === "Workflow")}
                         checked={!field.hidden}
                         onCheckedChange={(checked) => {
                           update(index, { ...field, hidden: !checked });

--- a/packages/trpc/server/routers/viewer/workflows/update.schema.ts
+++ b/packages/trpc/server/routers/viewer/workflows/update.schema.ts
@@ -17,7 +17,12 @@ export const ZUpdateInputSchema = z.object({
       stepNumber: z.number(),
       action: z.enum(WORKFLOW_ACTIONS),
       workflowId: z.number(),
-      sendTo: z.string().nullable(),
+      sendTo: z
+        .string()
+        .nullable()
+        .optional()
+        .transform((val) => val ?? null),
+      // sendTo: z.string().nullable(),
       reminderBody: z.string().nullable(),
       emailSubject: z.string().nullable(),
       template: z.enum(WORKFLOW_TEMPLATES),
@@ -25,7 +30,11 @@ export const ZUpdateInputSchema = z.object({
       sender: z.string().nullable(),
       senderName: z.string().nullable(),
       includeCalendarEvent: z.boolean(),
-      disableOnMarkNoShow: z.boolean().nullable().optional(),
+      disableOnMarkNoShow: z
+        .boolean()
+        .nullable()
+        .optional()
+        .transform((val) => val ?? null),
     })
     .array(),
   trigger: z.enum(WORKFLOW_TRIGGER_EVENTS),

--- a/packages/trpc/server/routers/viewer/workflows/util.ts
+++ b/packages/trpc/server/routers/viewer/workflows/util.ts
@@ -3,7 +3,7 @@ import type { z } from "zod";
 
 import { SMS_REMINDER_NUMBER_FIELD } from "@calcom/features/bookings/lib/SystemField";
 import {
-  getSmsReminderNumberField,
+  // getSmsReminderNumberField,
   getSmsReminderNumberSource,
 } from "@calcom/features/bookings/lib/getBookingFields";
 import { removeBookingField, upsertBookingField } from "@calcom/features/eventtypes/lib/bookingFieldsManager";
@@ -260,7 +260,7 @@ export async function upsertSmsReminderFieldForEventTypes({
 
   for (const eventTypeId of allEventTypeIds) {
     await upsertBookingField(
-      getSmsReminderNumberField(),
+      // getSmsReminderNumberField(),
       getSmsReminderNumberSource({
         workflowId,
         isSmsReminderNumberRequired,


### PR DESCRIPTION
- Removed Extra phone field when SMS workflow was added in event-type . 
- the logic of SMS field is merged with default phone field.
- In Booking Page the desc of booked event is now not showing Undefined.
- Specific email is now able to verify .
- Sms workflow reminder is working and received by users.
- When a user selects Sms workflow , the phone field becomes required and cannot be changed .

