### PR TITLE
fix: updated razorpay webhook to silently handle payment link not found

### DIFF
--- a/packages/app-store/razorpay/api/webhook.ts
+++ b/packages/app-store/razorpay/api/webhook.ts
@@ -109,7 +109,7 @@ async function handlePaymentLinkPaid({
     // throw new HttpCode({ statusCode: 404, message: "Payment not found" });
   }
 
-  if (!payment.success) {
+  if (payment && !payment.success) {
     await handlePaymentSuccess(payment.id, payment.bookingId, { paymentId });
   }
 }

--- a/packages/app-store/razorpay/api/webhook.ts
+++ b/packages/app-store/razorpay/api/webhook.ts
@@ -98,7 +98,16 @@ async function handlePaymentLinkPaid({
     where: { externalId: paymentLinkId },
     select: { id: true, bookingId: true, success: true },
   });
-  if (!payment) throw new HttpCode({ statusCode: 404, message: "Payment not found" });
+  if (!payment) {
+    logger.warn({
+      message: "Payment not found for the given payment link",
+      paymentLinkId,
+      paymentId,
+    });
+    //Not throwing 404 here, as this is a webhook and we don't want to fail the webhook processing
+    // as payment link could be created outside of cal.id too and failing here multiple times will cause webhook to be disabled
+    // throw new HttpCode({ statusCode: 404, message: "Payment not found" });
+  }
 
   if (!payment.success) {
     await handlePaymentSuccess(payment.id, payment.bookingId, { paymentId });


### PR DESCRIPTION
Payment link might be created from external source other than from Cal ID, and webhook will be triggered regardless and our app throws payment link not found error, which make razorpay try to send subsequent requent until it eventually dies and gets disabled.

So this PR fixes that issue by silently logging payment not found and continuing further